### PR TITLE
[Registry] Rename ServiceRegistry to Registry

### DIFF
--- a/src/Bundle/GridBundle/Batch/Type/DeleteType.php
+++ b/src/Bundle/GridBundle/Batch/Type/DeleteType.php
@@ -13,7 +13,7 @@ namespace Lug\Bundle\GridBundle\Batch\Type;
 
 use Lug\Bundle\ResourceBundle\Routing\ParameterResolverInterface;
 use Lug\Component\Grid\Batch\Type\AbstractType;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Exception\DomainException;
 
 /**
@@ -22,7 +22,7 @@ use Lug\Component\Resource\Exception\DomainException;
 class DeleteType extends AbstractType
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $domainManagerRegistry;
 
@@ -32,11 +32,11 @@ class DeleteType extends AbstractType
     private $parameterResolver;
 
     /**
-     * @param ServiceRegistryInterface   $domainManagerRegistry
+     * @param RegistryInterface          $domainManagerRegistry
      * @param ParameterResolverInterface $parameterResolver
      */
     public function __construct(
-        ServiceRegistryInterface $domainManagerRegistry,
+        RegistryInterface $domainManagerRegistry,
         ParameterResolverInterface $parameterResolver
     ) {
         $this->domainManagerRegistry = $domainManagerRegistry;

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterActionPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterActionPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterActionPass extends AbstractRegisterServiceRegistryPass
+class RegisterActionPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterBatchFormSubscriberPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterBatchFormSubscriberPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterBatchFormSubscriberPass extends AbstractRegisterServiceRegistryPass
+class RegisterBatchFormSubscriberPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterBatchPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterBatchPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterBatchPass extends AbstractRegisterServiceRegistryPass
+class RegisterBatchPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterColumnPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterColumnPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterColumnPass extends AbstractRegisterServiceRegistryPass
+class RegisterColumnPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterFilterFormPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterFilterFormPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterFilterFormPass extends AbstractRegisterServiceRegistryPass
+class RegisterFilterFormPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterFilterPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterFilterPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterFilterPass extends AbstractRegisterServiceRegistryPass
+class RegisterFilterPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterSortPass.php
+++ b/src/Bundle/GridBundle/DependencyInjection/Compiler/RegisterSortPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\GridBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterSortPass extends AbstractRegisterServiceRegistryPass
+class RegisterSortPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/GridBundle/Form/EventSubscriber/Batch/AbstractGridBatchSubscriber.php
+++ b/src/Bundle/GridBundle/Form/EventSubscriber/Batch/AbstractGridBatchSubscriber.php
@@ -14,7 +14,7 @@ namespace Lug\Bundle\GridBundle\Form\EventSubscriber\Batch;
 use Lug\Bundle\GridBundle\Form\Type\Batch\GridBatchValueType;
 use Lug\Bundle\ResourceBundle\Routing\ParameterResolverInterface;
 use Lug\Component\Grid\Model\GridInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
@@ -27,7 +27,7 @@ use Symfony\Component\Form\FormInterface;
 abstract class AbstractGridBatchSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $repositoryRegistry;
 
@@ -37,11 +37,11 @@ abstract class AbstractGridBatchSubscriber implements EventSubscriberInterface
     private $parameterResolver;
 
     /**
-     * @param ServiceRegistryInterface   $repositoryRegistry
+     * @param RegistryInterface          $repositoryRegistry
      * @param ParameterResolverInterface $parameterResolver
      */
     public function __construct(
-        ServiceRegistryInterface $repositoryRegistry,
+        RegistryInterface $repositoryRegistry,
         ParameterResolverInterface $parameterResolver
     ) {
         $this->repositoryRegistry = $repositoryRegistry;

--- a/src/Bundle/GridBundle/Form/EventSubscriber/Filter/ResourceFilterSubscriber.php
+++ b/src/Bundle/GridBundle/Form/EventSubscriber/Filter/ResourceFilterSubscriber.php
@@ -12,7 +12,7 @@
 namespace Lug\Bundle\GridBundle\Form\EventSubscriber\Filter;
 
 use Lug\Component\Grid\Filter\Type\ResourceType;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -24,14 +24,14 @@ use Symfony\Component\Form\FormInterface;
 class ResourceFilterSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
+     * @param RegistryInterface $resourceRegistry
      */
-    public function __construct(ServiceRegistryInterface $resourceRegistry)
+    public function __construct(RegistryInterface $resourceRegistry)
     {
         $this->resourceRegistry = $resourceRegistry;
     }

--- a/src/Bundle/GridBundle/Form/Type/Batch/GridBatchType.php
+++ b/src/Bundle/GridBundle/Form/Type/Batch/GridBatchType.php
@@ -12,7 +12,7 @@
 namespace Lug\Bundle\GridBundle\Form\Type\Batch;
 
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -24,14 +24,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class GridBatchType extends AbstractType
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $gridBatchSubscriberRegistry;
 
     /**
-     * @param ServiceRegistryInterface $gridBatchSubscriberRegistry
+     * @param RegistryInterface $gridBatchSubscriberRegistry
      */
-    public function __construct(ServiceRegistryInterface $gridBatchSubscriberRegistry)
+    public function __construct(RegistryInterface $gridBatchSubscriberRegistry)
     {
         $this->gridBatchSubscriberRegistry = $gridBatchSubscriberRegistry;
     }

--- a/src/Bundle/GridBundle/Model/Builder/FilterBuilder.php
+++ b/src/Bundle/GridBundle/Model/Builder/FilterBuilder.php
@@ -14,7 +14,7 @@ namespace Lug\Bundle\GridBundle\Model\Builder;
 use Lug\Bundle\GridBundle\Model\Filter;
 use Lug\Bundle\ResourceBundle\Util\ClassUtils;
 use Lug\Component\Grid\Model\Builder\FilterBuilder as BaseFilterBuilder;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -22,14 +22,14 @@ use Lug\Component\Registry\Model\ServiceRegistryInterface;
 class FilterBuilder extends BaseFilterBuilder
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $filterFormRegistry;
 
     /**
-     * @param ServiceRegistryInterface $filterFormRegistry
+     * @param RegistryInterface $filterFormRegistry
      */
-    public function __construct(ServiceRegistryInterface $filterFormRegistry)
+    public function __construct(RegistryInterface $filterFormRegistry)
     {
         $this->filterFormRegistry = $filterFormRegistry;
     }

--- a/src/Bundle/GridBundle/Registry/EventSubscriberRegistry.php
+++ b/src/Bundle/GridBundle/Registry/EventSubscriberRegistry.php
@@ -11,13 +11,13 @@
 
 namespace Lug\Bundle\GridBundle\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class EventSubscriberRegistry extends ServiceRegistry
+class EventSubscriberRegistry extends Registry
 {
     /**
      * @param EventSubscriberInterface[] $eventSubscribers

--- a/src/Bundle/GridBundle/Registry/FormTypeRegistry.php
+++ b/src/Bundle/GridBundle/Registry/FormTypeRegistry.php
@@ -11,13 +11,13 @@
 
 namespace Lug\Bundle\GridBundle\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class FormTypeRegistry extends ServiceRegistry
+class FormTypeRegistry extends Registry
 {
     /**
      * @param FormTypeInterface[] $formTypes

--- a/src/Bundle/GridBundle/Tests/Batch/Type/DeleteTypeTest.php
+++ b/src/Bundle/GridBundle/Tests/Batch/Type/DeleteTypeTest.php
@@ -15,7 +15,7 @@ use Lug\Bundle\GridBundle\Batch\Type\DeleteType;
 use Lug\Bundle\ResourceBundle\Routing\ParameterResolverInterface;
 use Lug\Component\Grid\Batch\Type\AbstractType;
 use Lug\Component\Grid\Model\GridInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Domain\DomainManagerInterface;
 use Lug\Component\Resource\Exception\DomainException;
 use Lug\Component\Resource\Model\ResourceInterface;
@@ -31,7 +31,7 @@ class DeleteTypeTest extends \PHPUnit_Framework_TestCase
     private $type;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $domainManagerRegistry;
 
@@ -230,11 +230,11 @@ class DeleteTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/GridBundle/Tests/Model/Builder/FilterBuilderTest.php
+++ b/src/Bundle/GridBundle/Tests/Model/Builder/FilterBuilderTest.php
@@ -13,7 +13,7 @@ namespace Lug\Bundle\GridBundle\Tests\Model\Builder;
 
 use Lug\Bundle\GridBundle\Model\Builder\FilterBuilder;
 use Lug\Component\Grid\Model\Builder\FilterBuilder as BaseFilterBuilder;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\Form\FormTypeInterface;
 
 /**
@@ -27,7 +27,7 @@ class FilterBuilderTest extends \PHPUnit_Framework_TestCase
     private $builder;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $filterFormRegistry;
 
@@ -86,11 +86,11 @@ class FilterBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/GridBundle/Tests/Registry/EventSubscriberRegistryTest.php
+++ b/src/Bundle/GridBundle/Tests/Registry/EventSubscriberRegistryTest.php
@@ -12,7 +12,7 @@
 namespace Lug\Bundle\GridBundle\Tests\Registry;
 
 use Lug\Bundle\GridBundle\Registry\EventSubscriberRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -35,7 +35,7 @@ class EventSubscriberRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->eventSubscriberRegistry);
+        $this->assertInstanceOf(Registry::class, $this->eventSubscriberRegistry);
     }
 
     public function testDefaultState()

--- a/src/Bundle/GridBundle/Tests/Registry/FormTypeRegistryTest.php
+++ b/src/Bundle/GridBundle/Tests/Registry/FormTypeRegistryTest.php
@@ -12,7 +12,7 @@
 namespace Lug\Bundle\GridBundle\Tests\Registry;
 
 use Lug\Bundle\GridBundle\Registry\FormTypeRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Symfony\Component\Form\FormTypeInterface;
 
 /**
@@ -35,7 +35,7 @@ class FormTypeRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->formTypeRegistry);
+        $this->assertInstanceOf(Registry::class, $this->formTypeRegistry);
     }
 
     public function testDefaultState()

--- a/src/Bundle/RegistryBundle/DependencyInjection/Compiler/AbstractRegisterRegistryPass.php
+++ b/src/Bundle/RegistryBundle/DependencyInjection/Compiler/AbstractRegisterRegistryPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-abstract class AbstractRegisterServiceRegistryPass implements CompilerPassInterface
+abstract class AbstractRegisterRegistryPass implements CompilerPassInterface
 {
     /**
      * @var string

--- a/src/Bundle/RegistryBundle/DependencyInjection/Compiler/ConvertRegistryPass.php
+++ b/src/Bundle/RegistryBundle/DependencyInjection/Compiler/ConvertRegistryPass.php
@@ -11,8 +11,8 @@
 
 namespace Lug\Bundle\RegistryBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\Model\LazyServiceRegistry;
-use Lug\Bundle\RegistryBundle\Model\LazyServiceRegistryInterface;
+use Lug\Bundle\RegistryBundle\Model\LazyRegistry;
+use Lug\Bundle\RegistryBundle\Model\LazyRegistryInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ConvertServiceRegistryPass implements CompilerPassInterface
+class ConvertRegistryPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
@@ -31,7 +31,7 @@ class ConvertServiceRegistryPass implements CompilerPassInterface
         foreach (array_keys($container->findTaggedServiceIds($tag = 'lug.registry')) as $registry) {
             $definition = $container->getDefinition($registry);
 
-            if (is_subclass_of($definition->getClass(), LazyServiceRegistryInterface::class)) {
+            if (is_subclass_of($definition->getClass(), LazyRegistryInterface::class)) {
                 continue;
             }
 
@@ -50,7 +50,7 @@ class ConvertServiceRegistryPass implements CompilerPassInterface
      */
     private function createLazyDefinition($registry, Definition $definition)
     {
-        $lazy = new Definition(LazyServiceRegistry::class, [
+        $lazy = new Definition(LazyRegistry::class, [
             new Reference('service_container'),
             new Reference($registry),
         ]);

--- a/src/Bundle/RegistryBundle/LugRegistryBundle.php
+++ b/src/Bundle/RegistryBundle/LugRegistryBundle.php
@@ -11,7 +11,7 @@
 
 namespace Lug\Bundle\RegistryBundle;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\ConvertServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\ConvertRegistryPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -25,6 +25,6 @@ class LugRegistryBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new ConvertServiceRegistryPass());
+        $container->addCompilerPass(new ConvertRegistryPass());
     }
 }

--- a/src/Bundle/RegistryBundle/Model/LazyRegistry.php
+++ b/src/Bundle/RegistryBundle/Model/LazyRegistry.php
@@ -13,13 +13,13 @@ namespace Lug\Bundle\RegistryBundle\Model;
 
 use Lug\Bundle\RegistryBundle\Exception\LazyServiceAlreadyExistsException;
 use Lug\Bundle\RegistryBundle\Exception\LazyServiceNotFoundException;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class LazyServiceRegistry implements LazyServiceRegistryInterface
+class LazyRegistry implements LazyRegistryInterface
 {
     /**
      * @var ContainerInterface
@@ -27,7 +27,7 @@ class LazyServiceRegistry implements LazyServiceRegistryInterface
     private $container;
 
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $registry;
 
@@ -37,11 +37,11 @@ class LazyServiceRegistry implements LazyServiceRegistryInterface
     private $services = [];
 
     /**
-     * @param ContainerInterface       $container
-     * @param ServiceRegistryInterface $registry
-     * @param string[]                 $services
+     * @param ContainerInterface $container
+     * @param RegistryInterface  $registry
+     * @param string[]           $services
      */
-    public function __construct(ContainerInterface $container, ServiceRegistryInterface $registry, array $services = [])
+    public function __construct(ContainerInterface $container, RegistryInterface $registry, array $services = [])
     {
         $this->container = $container;
         $this->registry = $registry;

--- a/src/Bundle/RegistryBundle/Model/LazyRegistryInterface.php
+++ b/src/Bundle/RegistryBundle/Model/LazyRegistryInterface.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\RegistryBundle\Model;
 
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-interface LazyServiceRegistryInterface extends ServiceRegistryInterface
+interface LazyRegistryInterface extends RegistryInterface
 {
     /**
      * @param string $type

--- a/src/Bundle/RegistryBundle/Tests/DependencyInjection/Compiler/ConvertRegistryPassTest.php
+++ b/src/Bundle/RegistryBundle/Tests/DependencyInjection/Compiler/ConvertRegistryPassTest.php
@@ -11,9 +11,9 @@
 
 namespace Lug\Bundle\RegistryBundle\Tests\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\ConvertServiceRegistryPass;
-use Lug\Bundle\RegistryBundle\Model\LazyServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\ConvertRegistryPass;
+use Lug\Bundle\RegistryBundle\Model\LazyRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -21,10 +21,10 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ConvertServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
+class ConvertRegistryPassTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ConvertServiceRegistryPass
+     * @var ConvertRegistryPass
      */
     private $compiler;
 
@@ -39,7 +39,7 @@ class ConvertServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->container = $this->createContainerMock();
-        $this->compiler = new ConvertServiceRegistryPass();
+        $this->compiler = new ConvertRegistryPass();
     }
 
     public function testProcess()
@@ -59,7 +59,7 @@ class ConvertServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
         $definition
             ->expects($this->once())
             ->method('getClass')
-            ->will($this->returnValue(ServiceRegistry::class));
+            ->will($this->returnValue(Registry::class));
 
         $definition
             ->expects($this->once())
@@ -100,7 +100,7 @@ class ConvertServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
                 [$service.'.internal', $definition],
                 [$service, $this->callback(function ($definition) use ($service, $types) {
                     $result = $definition instanceof Definition
-                        && $definition->getClass() === LazyServiceRegistry::class
+                        && $definition->getClass() === LazyRegistry::class
                         && count($definition->getArguments()) === 2
                         && $definition->getArgument(0) instanceof Reference
                         && (string) $definition->getArgument(0) === 'service_container'
@@ -138,7 +138,7 @@ class ConvertServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
         $definition
             ->expects($this->once())
             ->method('getClass')
-            ->will($this->returnValue(LazyServiceRegistry::class));
+            ->will($this->returnValue(LazyRegistry::class));
 
         $definition
             ->expects($this->never())

--- a/src/Bundle/RegistryBundle/Tests/DependencyInjection/Compiler/RegisterRegistryPassTest.php
+++ b/src/Bundle/RegistryBundle/Tests/DependencyInjection/Compiler/RegisterRegistryPassTest.php
@@ -11,7 +11,7 @@
 
 namespace Lug\Bundle\RegistryBundle\Tests\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -20,10 +20,10 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
+class RegisterRegistryPassTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var AbstractRegisterServiceRegistryPass
+     * @var AbstractRegisterRegistryPass
      */
     private $compiler;
 
@@ -51,7 +51,7 @@ class RegisterServiceRegistryPassTest extends \PHPUnit_Framework_TestCase
         $this->tag = 'my.tag';
         $this->attribute = 'my.alias';
 
-        $this->compiler = $this->getMockBuilder(AbstractRegisterServiceRegistryPass::class)
+        $this->compiler = $this->getMockBuilder(AbstractRegisterRegistryPass::class)
             ->setConstructorArgs([$this->registry, $this->tag, $this->attribute])
             ->getMockForAbstractClass();
     }

--- a/src/Bundle/RegistryBundle/Tests/LugRegistryBundleTest.php
+++ b/src/Bundle/RegistryBundle/Tests/LugRegistryBundleTest.php
@@ -11,7 +11,7 @@
 
 namespace Lug\Bundle\RegistryBundle\Tests;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\ConvertServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\ConvertRegistryPass;
 use Lug\Bundle\RegistryBundle\LugRegistryBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -45,7 +45,7 @@ class LugRegistryBundleTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->once())
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(ConvertServiceRegistryPass::class));
+            ->with($this->isInstanceOf(ConvertRegistryPass::class));
 
         $this->bundle->build($container);
     }

--- a/src/Bundle/RegistryBundle/Tests/Model/LazyRegistryTest.php
+++ b/src/Bundle/RegistryBundle/Tests/Model/LazyRegistryTest.php
@@ -11,26 +11,26 @@
 
 namespace Lug\Bundle\RegistryBundle\Tests\Model;
 
-use Lug\Bundle\RegistryBundle\Model\LazyServiceRegistry;
-use Lug\Bundle\RegistryBundle\Model\LazyServiceRegistryInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Bundle\RegistryBundle\Model\LazyRegistry;
+use Lug\Bundle\RegistryBundle\Model\LazyRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
+class LazyRegistryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var LazyServiceRegistry
+     * @var LazyRegistry
      */
-    private $lazyServiceRegistry;
+    private $lazyRegistry;
 
     /**
-     * @var ServiceRegistry|\PHPUnit_Framework_MockObject_MockObject
+     * @var Registry|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $serviceRegistry;
+    private $registry;
 
     /**
      * @var ContainerInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -61,30 +61,30 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
         $this->containerServices = ['my.baz' => $this->createServiceMock(), 'my.bat' => $this->createServiceMock()];
         $this->lazyServices = ['baz' => 'my.baz', 'bat' => 'my.bat'];
         $this->container = $this->createContainerMock();
-        $this->serviceRegistry = new ServiceRegistry(ServiceInterface::class, $this->services);
+        $this->registry = new Registry(ServiceInterface::class, $this->services);
 
-        $this->lazyServiceRegistry = new LazyServiceRegistry(
+        $this->lazyRegistry = new LazyRegistry(
             $this->container,
-            $this->serviceRegistry,
+            $this->registry,
             $this->lazyServices
         );
     }
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->lazyServiceRegistry);
-        $this->assertInstanceOf(LazyServiceRegistryInterface::class, $this->lazyServiceRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->lazyRegistry);
+        $this->assertInstanceOf(LazyRegistryInterface::class, $this->lazyRegistry);
     }
 
     public function testDefaultState()
     {
-        $this->lazyServiceRegistry = new LazyServiceRegistry(
+        $this->lazyRegistry = new LazyRegistry(
             $this->container,
-            new ServiceRegistry(ServiceInterface::class)
+            new Registry(ServiceInterface::class)
         );
 
-        $this->assertEmpty(iterator_to_array($this->lazyServiceRegistry));
-        $this->assertCount(0, $this->lazyServiceRegistry);
+        $this->assertEmpty(iterator_to_array($this->lazyRegistry));
+        $this->assertCount(0, $this->lazyRegistry);
     }
 
     public function testInitialState()
@@ -94,25 +94,25 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
             array_combine(array_flip($this->lazyServices), $this->containerServices)
         );
 
-        $this->assertSame($services, iterator_to_array($this->lazyServiceRegistry));
-        $this->assertCount(count($services), $this->lazyServiceRegistry);
+        $this->assertSame($services, iterator_to_array($this->lazyRegistry));
+        $this->assertCount(count($services), $this->lazyRegistry);
     }
 
     public function testHasLazy()
     {
         foreach (array_keys($this->lazyServices) as $type) {
-            $this->assertTrue($this->lazyServiceRegistry->hasLazy($type));
+            $this->assertTrue($this->lazyRegistry->hasLazy($type));
         }
 
         foreach (array_keys($this->services) as $type) {
-            $this->assertFalse($this->lazyServiceRegistry->hasLazy($type));
+            $this->assertFalse($this->lazyRegistry->hasLazy($type));
         }
     }
 
     public function testGetLazy()
     {
         foreach ($this->lazyServices as $type => $service) {
-            $this->assertSame($service, $this->lazyServiceRegistry->getLazy($type));
+            $this->assertSame($service, $this->lazyRegistry->getLazy($type));
         }
     }
 
@@ -122,7 +122,7 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLazyWithNonExistingLazy()
     {
-        $this->lazyServiceRegistry->getLazy('foo');
+        $this->lazyRegistry->getLazy('foo');
     }
 
     public function testSetLazy()
@@ -130,27 +130,27 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
         $this->containerServices[$containerService = 'my.ban'] = $service = $this->createServiceMock();
 
         $this->container = $this->createContainerMock();
-        $this->serviceRegistry = new ServiceRegistry(ServiceInterface::class, $this->services);
+        $this->registry = new Registry(ServiceInterface::class, $this->services);
 
-        $this->lazyServiceRegistry = new LazyServiceRegistry(
+        $this->lazyRegistry = new LazyRegistry(
             $this->container,
-            $this->serviceRegistry,
+            $this->registry,
             $this->lazyServices
         );
 
         $this->lazyServices[$type = 'ban'] = $containerService;
-        $this->lazyServiceRegistry->setLazy($type, $containerService);
+        $this->lazyRegistry->setLazy($type, $containerService);
 
-        $this->assertTrue($this->lazyServiceRegistry->hasLazy($type));
-        $this->assertSame($containerService, $this->lazyServiceRegistry->getLazy($type));
+        $this->assertTrue($this->lazyRegistry->hasLazy($type));
+        $this->assertSame($containerService, $this->lazyRegistry->getLazy($type));
 
         $services = array_merge(
             $this->services,
             array_combine(array_flip($this->lazyServices), $this->containerServices)
         );
 
-        $this->assertSame($services, iterator_to_array($this->lazyServiceRegistry));
-        $this->assertCount(count($services), $this->lazyServiceRegistry);
+        $this->assertSame($services, iterator_to_array($this->lazyRegistry));
+        $this->assertCount(count($services), $this->lazyRegistry);
     }
 
     /**
@@ -159,7 +159,7 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetLazyWithExistingLazy()
     {
-        $this->lazyServiceRegistry->setLazy('baz', 'my.baz');
+        $this->lazyRegistry->setLazy('baz', 'my.baz');
     }
 
     public function testRemoveLazy()
@@ -167,11 +167,11 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
         $this->testInitialState();
 
         foreach (array_keys($this->lazyServices) as $type) {
-            $this->lazyServiceRegistry->removeLazy($type);
+            $this->lazyRegistry->removeLazy($type);
         }
 
-        $this->assertSame($this->services, iterator_to_array($this->lazyServiceRegistry));
-        $this->assertCount(count($this->services), $this->lazyServiceRegistry);
+        $this->assertSame($this->services, iterator_to_array($this->lazyRegistry));
+        $this->assertCount(count($this->services), $this->lazyRegistry);
     }
 
     /**
@@ -180,16 +180,16 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testRemoveLazyWithNonExistingLazy()
     {
-        $this->lazyServiceRegistry->removeLazy('ban');
+        $this->lazyRegistry->removeLazy('ban');
     }
 
     public function testOffsetExists()
     {
         foreach (array_keys(array_merge($this->services, $this->lazyServices)) as $type) {
-            $this->assertTrue(isset($this->lazyServiceRegistry[$type]));
+            $this->assertTrue(isset($this->lazyRegistry[$type]));
         }
 
-        $this->assertFalse(isset($this->lazyServiceRegistry['ban']));
+        $this->assertFalse(isset($this->lazyRegistry['ban']));
     }
 
     public function testOffsetGet()
@@ -200,7 +200,7 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
         );
 
         foreach ($services as $type => $service) {
-            $this->assertSame($service, $this->lazyServiceRegistry[$type]);
+            $this->assertSame($service, $this->lazyRegistry[$type]);
         }
     }
 
@@ -210,14 +210,14 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testOffsetGetWithNonExistingService()
     {
-        $this->lazyServiceRegistry['ban'];
+        $this->lazyRegistry['ban'];
     }
 
     public function testOffsetSet()
     {
-        $this->lazyServiceRegistry[$type = 'ban'] = $service = $this->createServiceMock();
+        $this->lazyRegistry[$type = 'ban'] = $service = $this->createServiceMock();
 
-        $this->assertSame($service, $this->lazyServiceRegistry[$type]);
+        $this->assertSame($service, $this->lazyRegistry[$type]);
 
         $services = array_merge(
             $this->services,
@@ -225,8 +225,8 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
             array_combine(array_flip($this->lazyServices), $this->containerServices)
         );
 
-        $this->assertSame($services, iterator_to_array($this->lazyServiceRegistry));
-        $this->assertCount(count($services), $this->lazyServiceRegistry);
+        $this->assertSame($services, iterator_to_array($this->lazyRegistry));
+        $this->assertCount(count($services), $this->lazyRegistry);
     }
 
     /**
@@ -235,19 +235,19 @@ class LazyServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testOffsetSetWithExistingService()
     {
-        $this->lazyServiceRegistry['baz'] = $this->createServiceMock();
+        $this->lazyRegistry['baz'] = $this->createServiceMock();
     }
 
     public function testOffsetUnset()
     {
         foreach (array_keys(array_merge($this->services, $this->lazyServices)) as $type) {
-            unset($this->lazyServiceRegistry[$type]);
+            unset($this->lazyRegistry[$type]);
 
-            $this->assertFalse(isset($this->lazyServiceRegistry[$type]));
+            $this->assertFalse(isset($this->lazyRegistry[$type]));
         }
 
-        $this->assertEmpty(iterator_to_array($this->lazyServiceRegistry));
-        $this->assertCount(0, $this->lazyServiceRegistry);
+        $this->assertEmpty(iterator_to_array($this->lazyRegistry));
+        $this->assertCount(0, $this->lazyRegistry);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterDomainManagerPass.php
+++ b/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterDomainManagerPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterDomainManagerPass extends AbstractRegisterServiceRegistryPass
+class RegisterDomainManagerPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterFactoryPass.php
+++ b/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterFactoryPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterFactoryPass extends AbstractRegisterServiceRegistryPass
+class RegisterFactoryPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterManagerPass.php
+++ b/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterManagerPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterManagerPass extends AbstractRegisterServiceRegistryPass
+class RegisterManagerPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterRepositoryPass.php
+++ b/src/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterRepositoryPass.php
@@ -11,12 +11,12 @@
 
 namespace Lug\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
-use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterServiceRegistryPass;
+use Lug\Bundle\RegistryBundle\DependencyInjection\Compiler\AbstractRegisterRegistryPass;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RegisterRepositoryPass extends AbstractRegisterServiceRegistryPass
+class RegisterRepositoryPass extends AbstractRegisterRegistryPass
 {
     public function __construct()
     {

--- a/src/Bundle/ResourceBundle/DependencyInjection/Configurator/ResolveTargetSubscriberConfigurator.php
+++ b/src/Bundle/ResourceBundle/DependencyInjection/Configurator/ResolveTargetSubscriberConfigurator.php
@@ -12,7 +12,7 @@
 namespace Lug\Bundle\ResourceBundle\DependencyInjection\Configurator;
 
 use Lug\Bundle\ResourceBundle\EventSubscriber\ResolveTargetSubscriberInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -20,14 +20,14 @@ use Lug\Component\Registry\Model\ServiceRegistryInterface;
 class ResolveTargetSubscriberConfigurator
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
+     * @param RegistryInterface $resourceRegistry
      */
-    public function __construct(ServiceRegistryInterface $resourceRegistry)
+    public function __construct(RegistryInterface $resourceRegistry)
     {
         $this->resourceRegistry = $resourceRegistry;
     }

--- a/src/Bundle/ResourceBundle/EventSubscriber/Doctrine/MongoDB/ResourceSubscriber.php
+++ b/src/Bundle/ResourceBundle/EventSubscriber/Doctrine/MongoDB/ResourceSubscriber.php
@@ -14,7 +14,7 @@ namespace Lug\Bundle\ResourceBundle\EventSubscriber\Doctrine\MongoDB;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -23,14 +23,14 @@ use Lug\Component\Resource\Model\ResourceInterface;
 class ResourceSubscriber implements EventSubscriber
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @param ServiceRegistryInterface $registry
+     * @param RegistryInterface $registry
      */
-    public function __construct(ServiceRegistryInterface $registry)
+    public function __construct(RegistryInterface $registry)
     {
         $this->resourceRegistry = $registry;
     }

--- a/src/Bundle/ResourceBundle/EventSubscriber/Doctrine/ORM/ResourceSubscriber.php
+++ b/src/Bundle/ResourceBundle/EventSubscriber/Doctrine/ORM/ResourceSubscriber.php
@@ -14,7 +14,7 @@ namespace Lug\Bundle\ResourceBundle\EventSubscriber\Doctrine\ORM;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -23,14 +23,14 @@ use Lug\Component\Resource\Model\ResourceInterface;
 class ResourceSubscriber implements EventSubscriber
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @param ServiceRegistryInterface $registry
+     * @param RegistryInterface $registry
      */
-    public function __construct(ServiceRegistryInterface $registry)
+    public function __construct(RegistryInterface $registry)
     {
         $this->resourceRegistry = $registry;
     }

--- a/src/Bundle/ResourceBundle/Form/EventSubscriber/CollectionSubscriber.php
+++ b/src/Bundle/ResourceBundle/Form/EventSubscriber/CollectionSubscriber.php
@@ -13,7 +13,7 @@ namespace Lug\Bundle\ResourceBundle\Form\EventSubscriber;
 
 use Doctrine\Common\Collections\Collection;
 use Lug\Bundle\ResourceBundle\Util\ClassUtils;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
@@ -27,12 +27,12 @@ use Symfony\Component\Form\FormEvents;
 class CollectionSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $managerRegistry;
 
@@ -47,10 +47,10 @@ class CollectionSubscriber implements EventSubscriberInterface
     private $cache = [];
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
-     * @param ServiceRegistryInterface $managerRegistry
+     * @param RegistryInterface $resourceRegistry
+     * @param RegistryInterface $managerRegistry
      */
-    public function __construct(ServiceRegistryInterface $resourceRegistry, ServiceRegistryInterface $managerRegistry)
+    public function __construct(RegistryInterface $resourceRegistry, RegistryInterface $managerRegistry)
     {
         $this->resourceRegistry = $resourceRegistry;
         $this->managerRegistry = $managerRegistry;

--- a/src/Bundle/ResourceBundle/Repository/Doctrine/MongoDB/RepositoryFactory.php
+++ b/src/Bundle/ResourceBundle/Repository/Doctrine/MongoDB/RepositoryFactory.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Repository\DefaultRepositoryFactory;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Resource\Repository\RepositoryInterface as BaseRepositoryInterface;
 
@@ -25,14 +25,14 @@ use Lug\Component\Resource\Repository\RepositoryInterface as BaseRepositoryInter
 class RepositoryFactory extends DefaultRepositoryFactory
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
+     * @param RegistryInterface $resourceRegistry
      */
-    public function __construct(ServiceRegistryInterface $resourceRegistry)
+    public function __construct(RegistryInterface $resourceRegistry)
     {
         $this->resourceRegistry = $resourceRegistry;
     }

--- a/src/Bundle/ResourceBundle/Repository/Doctrine/ORM/RepositoryFactory.php
+++ b/src/Bundle/ResourceBundle/Repository/Doctrine/ORM/RepositoryFactory.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\RepositoryFactory as RepositoryFactoryInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Resource\Repository\RepositoryInterface as BaseRepositoryInterface;
 
@@ -25,7 +25,7 @@ use Lug\Component\Resource\Repository\RepositoryInterface as BaseRepositoryInter
 class RepositoryFactory implements RepositoryFactoryInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
@@ -35,9 +35,9 @@ class RepositoryFactory implements RepositoryFactoryInterface
     private $cache = [];
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
+     * @param RegistryInterface $resourceRegistry
      */
-    public function __construct(ServiceRegistryInterface $resourceRegistry)
+    public function __construct(RegistryInterface $resourceRegistry)
     {
         $this->resourceRegistry = $resourceRegistry;
     }

--- a/src/Bundle/ResourceBundle/Tests/DependencyInjection/Configurator/ResolveTargetEntitySubscriberConfiguratorTest.php
+++ b/src/Bundle/ResourceBundle/Tests/DependencyInjection/Configurator/ResolveTargetEntitySubscriberConfiguratorTest.php
@@ -13,7 +13,7 @@ namespace Lug\Bundle\ResourceBundle\Tests\DependencyInjection\Configurator;
 
 use Lug\Bundle\ResourceBundle\DependencyInjection\Configurator\ResolveTargetSubscriberConfigurator;
 use Lug\Bundle\ResourceBundle\EventSubscriber\ResolveTargetSubscriberInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -27,7 +27,7 @@ class ResolveTargetEntitySubscriberConfiguratorTest extends \PHPUnit_Framework_T
     private $configurator;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $serviceRegistry;
 
@@ -70,11 +70,11 @@ class ResolveTargetEntitySubscriberConfiguratorTest extends \PHPUnit_Framework_T
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/EventSubscriber/Doctrine/MongoDB/ResourceSubscriberTest.php
+++ b/src/Bundle/ResourceBundle/Tests/EventSubscriber/Doctrine/MongoDB/ResourceSubscriberTest.php
@@ -16,7 +16,7 @@ use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Lug\Bundle\ResourceBundle\EventSubscriber\Doctrine\MongoDB\ResourceSubscriber;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -30,7 +30,7 @@ class ResourceSubscriberTest extends \PHPUnit_Framework_TestCase
     private $resourceSubscriber;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $serviceRegistry;
 
@@ -127,11 +127,11 @@ class ResourceSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/EventSubscriber/Doctrine/ORM/ResourceSubscriberTest.php
+++ b/src/Bundle/ResourceBundle/Tests/EventSubscriber/Doctrine/ORM/ResourceSubscriberTest.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Lug\Bundle\ResourceBundle\EventSubscriber\Doctrine\ORM\ResourceSubscriber;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -30,7 +30,7 @@ class ResourceSubscriberTest extends \PHPUnit_Framework_TestCase
     private $resourceSubscriber;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $serviceRegistry;
 
@@ -123,11 +123,11 @@ class ResourceSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/Form/EventSubscriber/CollectionSubscriberTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Form/EventSubscriber/CollectionSubscriberTest.php
@@ -14,7 +14,7 @@ namespace Lug\Bundle\ResourceBundle\Tests\Form\EventSubscriber;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ObjectManager;
 use Lug\Bundle\ResourceBundle\Form\EventSubscriber\CollectionSubscriber;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
@@ -32,12 +32,12 @@ class CollectionSubscriberTest extends \PHPUnit_Framework_TestCase
     private $subscriber;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $managerRegistry;
 
@@ -255,11 +255,11 @@ class CollectionSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/Registry/DomainManagerRegistryTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Registry/DomainManagerRegistryTest.php
@@ -11,8 +11,8 @@
 
 namespace Lug\Bundle\ResourceBundle\Tests\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Domain\DomainManagerInterface;
 use Lug\Component\Resource\Registry\DomainManagerRegistry;
 
@@ -36,8 +36,8 @@ class DomainManagerRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->domainManagerRegistry);
-        $this->assertInstanceOf(ServiceRegistry::class, $this->domainManagerRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->domainManagerRegistry);
+        $this->assertInstanceOf(Registry::class, $this->domainManagerRegistry);
     }
 
     public function testDefaultState()

--- a/src/Bundle/ResourceBundle/Tests/Repository/Doctrine/MongoDB/RepositoryFactoryTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Repository/Doctrine/MongoDB/RepositoryFactoryTest.php
@@ -19,7 +19,7 @@ use Doctrine\ODM\MongoDB\Repository\RepositoryFactory as RepositoryFactoryInterf
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Lug\Bundle\ResourceBundle\Repository\Doctrine\MongoDB\Repository;
 use Lug\Bundle\ResourceBundle\Repository\Doctrine\MongoDB\RepositoryFactory;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -33,7 +33,7 @@ class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     private $repositoryFactory;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -137,11 +137,11 @@ class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createResourceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/Repository/Doctrine/ORM/RepositoryFactoryTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Repository/Doctrine/ORM/RepositoryFactoryTest.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\RepositoryFactory as RepositoryFactoryInterface;
 use Lug\Bundle\ResourceBundle\Repository\Doctrine\ORM\Repository;
 use Lug\Bundle\ResourceBundle\Repository\Doctrine\ORM\RepositoryFactory;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -32,7 +32,7 @@ class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     private $repositoryFactory;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -122,11 +122,11 @@ class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createResourceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/TranslationBundle/EventSubscriber/TranslatableResourceSubscriber.php
+++ b/src/Bundle/TranslationBundle/EventSubscriber/TranslatableResourceSubscriber.php
@@ -15,7 +15,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Lug\Bundle\ResourceBundle\Util\ClassUtils;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Translation\Context\LocaleContextInterface;
 use Lug\Component\Translation\Model\TranslatableInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -82,7 +82,7 @@ class TranslatableResourceSubscriber implements EventSubscriber
     }
 
     /**
-     * @return ServiceRegistryInterface
+     * @return RegistryInterface
      */
     private function getResourceRegistry()
     {

--- a/src/Bundle/TranslationBundle/Tests/DependencyInjection/AbstractLugTranslationExtensionTest.php
+++ b/src/Bundle/TranslationBundle/Tests/DependencyInjection/AbstractLugTranslationExtensionTest.php
@@ -21,7 +21,7 @@ use Lug\Bundle\TranslationBundle\Provider\A2lixLocaleProvider;
 use Lug\Bundle\TranslationBundle\Repository\Doctrine\MongoDB\TranslatableRepositoryFactory as DoctrineMongoDBTranslatableRepositoryFactory;
 use Lug\Bundle\TranslationBundle\Repository\Doctrine\ORM\TranslatableRepositoryFactory as DoctrineORMTranslatableRepositoryFactory;
 use Lug\Component\Locale\Provider\LocaleProviderInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Repository\RepositoryInterface;
 use Lug\Component\Translation\Context\LocaleContextInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -63,7 +63,7 @@ abstract class AbstractLugTranslationExtensionTest extends \PHPUnit_Framework_Te
     private $localeProvider;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -207,11 +207,11 @@ abstract class AbstractLugTranslationExtensionTest extends \PHPUnit_Framework_Te
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/TranslationBundle/Tests/EventSubscriber/TranslatableResourceSubscriberTest.php
+++ b/src/Bundle/TranslationBundle/Tests/EventSubscriber/TranslatableResourceSubscriberTest.php
@@ -15,7 +15,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Lug\Bundle\TranslationBundle\EventSubscriber\TranslatableResourceSubscriber;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Translation\Context\LocaleContextInterface;
 use Lug\Component\Translation\Model\TranslatableInterface;
@@ -37,7 +37,7 @@ class TranslatableResourceSubscriberTest extends \PHPUnit_Framework_TestCase
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -172,11 +172,11 @@ class TranslatableResourceSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createResourceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/TranslationBundle/Tests/Repository/Doctrine/MongoDB/TranslatableRepositoryFactoryTest.php
+++ b/src/Bundle/TranslationBundle/Tests/Repository/Doctrine/MongoDB/TranslatableRepositoryFactoryTest.php
@@ -20,7 +20,7 @@ use Lug\Bundle\ResourceBundle\Repository\Doctrine\MongoDB\Repository;
 use Lug\Bundle\ResourceBundle\Repository\Doctrine\MongoDB\RepositoryFactory;
 use Lug\Bundle\TranslationBundle\Repository\Doctrine\MongoDB\TranslatableRepository;
 use Lug\Bundle\TranslationBundle\Repository\Doctrine\MongoDB\TranslatableRepositoryFactory;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Translation\Context\LocaleContextInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -41,7 +41,7 @@ class TranslatableRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -208,11 +208,11 @@ class TranslatableRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Bundle/TranslationBundle/Tests/Repository/Doctrine/ORM/TranslatableRepositoryFactoryTest.php
+++ b/src/Bundle/TranslationBundle/Tests/Repository/Doctrine/ORM/TranslatableRepositoryFactoryTest.php
@@ -19,7 +19,7 @@ use Lug\Bundle\ResourceBundle\Repository\Doctrine\ORM\Repository;
 use Lug\Bundle\ResourceBundle\Repository\Doctrine\ORM\RepositoryFactory;
 use Lug\Bundle\TranslationBundle\Repository\Doctrine\ORM\TranslatableRepository;
 use Lug\Bundle\TranslationBundle\Repository\Doctrine\ORM\TranslatableRepositoryFactory;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Translation\Context\LocaleContextInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -40,7 +40,7 @@ class TranslatableRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -188,11 +188,11 @@ class TranslatableRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Action/ActionRenderer.php
+++ b/src/Component/Grid/Action/ActionRenderer.php
@@ -14,7 +14,7 @@ namespace Lug\Component\Grid\Action;
 use Lug\Component\Grid\Action\Type\TypeInterface;
 use Lug\Component\Grid\Model\ActionInterface;
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ActionRenderer implements ActionRendererInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $actionRegistry;
 
@@ -33,9 +33,9 @@ class ActionRenderer implements ActionRendererInterface
     private $cache = [];
 
     /**
-     * @param ServiceRegistryInterface $actionRegistry
+     * @param RegistryInterface $actionRegistry
      */
-    public function __construct(ServiceRegistryInterface $actionRegistry)
+    public function __construct(RegistryInterface $actionRegistry)
     {
         $this->actionRegistry = $actionRegistry;
     }

--- a/src/Component/Grid/Batch/Batcher.php
+++ b/src/Component/Grid/Batch/Batcher.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Batch;
 
 use Lug\Component\Grid\Batch\Type\TypeInterface;
 use Lug\Component\Grid\Model\GridInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -22,19 +22,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Batcher implements BatcherInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $batchRegistry;
 
     /**
      * @var mixed[]
      */
-    private $cache;
+    private $cache = [];
 
     /**
-     * @param ServiceRegistryInterface $batchRegistry
+     * @param RegistryInterface $batchRegistry
      */
-    public function __construct(ServiceRegistryInterface $batchRegistry)
+    public function __construct(RegistryInterface $batchRegistry)
     {
         $this->batchRegistry = $batchRegistry;
     }

--- a/src/Component/Grid/Column/ColumnRenderer.php
+++ b/src/Component/Grid/Column/ColumnRenderer.php
@@ -14,7 +14,7 @@ namespace Lug\Component\Grid\Column;
 use Lug\Component\Grid\Column\Type\TypeInterface;
 use Lug\Component\Grid\Model\ColumnInterface;
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ColumnRenderer implements ColumnRendererInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $columnRegistry;
 
@@ -33,9 +33,9 @@ class ColumnRenderer implements ColumnRendererInterface
     private $cache = [];
 
     /**
-     * @param ServiceRegistryInterface $columnRegistry
+     * @param RegistryInterface $columnRegistry
      */
-    public function __construct(ServiceRegistryInterface $columnRegistry)
+    public function __construct(RegistryInterface $columnRegistry)
     {
         $this->columnRegistry = $columnRegistry;
     }

--- a/src/Component/Grid/Column/Type/ResourceType.php
+++ b/src/Component/Grid/Column/Type/ResourceType.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Column\Type;
 
 use Lug\Component\Grid\Column\ColumnRendererInterface;
 use Lug\Component\Grid\Model\Column;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -25,7 +25,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 class ResourceType extends AbstractType
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
@@ -46,12 +46,12 @@ class ResourceType extends AbstractType
 
     /**
      * @param PropertyAccessorInterface $propertyAccessor
-     * @param ServiceRegistryInterface  $resourceRegistry
+     * @param RegistryInterface         $resourceRegistry
      * @param ColumnRendererInterface   $renderer
      */
     public function __construct(
         PropertyAccessorInterface $propertyAccessor,
-        ServiceRegistryInterface $resourceRegistry,
+        RegistryInterface $resourceRegistry,
         ColumnRendererInterface $renderer
     ) {
         parent::__construct($propertyAccessor);

--- a/src/Component/Grid/Filter/Filterer.php
+++ b/src/Component/Grid/Filter/Filterer.php
@@ -14,7 +14,7 @@ namespace Lug\Component\Grid\Filter;
 use Lug\Component\Grid\DataSource\DataSourceBuilderInterface;
 use Lug\Component\Grid\Filter\Type\TypeInterface;
 use Lug\Component\Grid\Model\GridInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -23,14 +23,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Filterer implements FiltererInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $filterRegistry;
 
     /**
-     * @param ServiceRegistryInterface $filterRegistry
+     * @param RegistryInterface $filterRegistry
      */
-    public function __construct(ServiceRegistryInterface $filterRegistry)
+    public function __construct(RegistryInterface $filterRegistry)
     {
         $this->filterRegistry = $filterRegistry;
     }

--- a/src/Component/Grid/Filter/Type/ResourceType.php
+++ b/src/Component/Grid/Filter/Type/ResourceType.php
@@ -11,7 +11,7 @@
 
 namespace Lug\Component\Grid\Filter\Type;
 
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -27,14 +27,14 @@ class ResourceType extends AbstractType
     const TYPE_NOT_EMPTY = 'not_empty';
 
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
+     * @param RegistryInterface $resourceRegistry
      */
-    public function __construct(ServiceRegistryInterface $resourceRegistry)
+    public function __construct(RegistryInterface $resourceRegistry)
     {
         $this->resourceRegistry = $resourceRegistry;
     }

--- a/src/Component/Grid/Handler/GridHandler.php
+++ b/src/Component/Grid/Handler/GridHandler.php
@@ -16,7 +16,7 @@ use Lug\Component\Grid\Model\GridInterface;
 use Lug\Component\Grid\Slicer\SlicerInterface;
 use Lug\Component\Grid\Sort\SorterInterface;
 use Lug\Component\Grid\View\GridViewFactoryInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -24,7 +24,7 @@ use Lug\Component\Registry\Model\ServiceRegistryInterface;
 class GridHandler implements GridHandlerInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $repositoryRegistry;
 
@@ -49,14 +49,14 @@ class GridHandler implements GridHandlerInterface
     private $slicer;
 
     /**
-     * @param ServiceRegistryInterface $repositoryRegistry
+     * @param RegistryInterface        $repositoryRegistry
      * @param GridViewFactoryInterface $gridViewFactory
      * @param FiltererInterface        $filterer
      * @param SorterInterface          $sorter
      * @param SlicerInterface          $slicer
      */
     public function __construct(
-        ServiceRegistryInterface $repositoryRegistry,
+        RegistryInterface $repositoryRegistry,
         GridViewFactoryInterface $gridViewFactory,
         FiltererInterface $filterer,
         SorterInterface $sorter,

--- a/src/Component/Grid/Registry/ActionRegistry.php
+++ b/src/Component/Grid/Registry/ActionRegistry.php
@@ -12,12 +12,12 @@
 namespace Lug\Component\Grid\Registry;
 
 use Lug\Component\Grid\Action\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ActionRegistry extends ServiceRegistry
+class ActionRegistry extends Registry
 {
     /**
      * @param TypeInterface[] $actions

--- a/src/Component/Grid/Registry/BatchRegistry.php
+++ b/src/Component/Grid/Registry/BatchRegistry.php
@@ -12,12 +12,12 @@
 namespace Lug\Component\Grid\Registry;
 
 use Lug\Component\Grid\Batch\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class BatchRegistry extends ServiceRegistry
+class BatchRegistry extends Registry
 {
     /**
      * @param TypeInterface[] $batches

--- a/src/Component/Grid/Registry/ColumnRegistry.php
+++ b/src/Component/Grid/Registry/ColumnRegistry.php
@@ -12,12 +12,12 @@
 namespace Lug\Component\Grid\Registry;
 
 use Lug\Component\Grid\Column\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ColumnRegistry extends ServiceRegistry
+class ColumnRegistry extends Registry
 {
     /**
      * @param TypeInterface[] $columns

--- a/src/Component/Grid/Registry/FilterRegistry.php
+++ b/src/Component/Grid/Registry/FilterRegistry.php
@@ -12,12 +12,12 @@
 namespace Lug\Component\Grid\Registry;
 
 use Lug\Component\Grid\Filter\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class FilterRegistry extends ServiceRegistry
+class FilterRegistry extends Registry
 {
     /**
      * @param TypeInterface[] $types

--- a/src/Component/Grid/Registry/SortRegistry.php
+++ b/src/Component/Grid/Registry/SortRegistry.php
@@ -12,12 +12,12 @@
 namespace Lug\Component\Grid\Registry;
 
 use Lug\Component\Grid\Sort\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class SortRegistry extends ServiceRegistry
+class SortRegistry extends Registry
 {
     /**
      * @param TypeInterface[] $types

--- a/src/Component/Grid/Sort/Sorter.php
+++ b/src/Component/Grid/Sort/Sorter.php
@@ -14,7 +14,7 @@ namespace Lug\Component\Grid\Sort;
 use Lug\Component\Grid\DataSource\DataSourceBuilderInterface;
 use Lug\Component\Grid\Model\GridInterface;
 use Lug\Component\Grid\Sort\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -23,14 +23,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class Sorter implements SorterInterface
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $sortRegistry;
 
     /**
-     * @param ServiceRegistryInterface $sortRegistry
+     * @param RegistryInterface $sortRegistry
      */
-    public function __construct(ServiceRegistryInterface $sortRegistry)
+    public function __construct(RegistryInterface $sortRegistry)
     {
         $this->sortRegistry = $sortRegistry;
     }

--- a/src/Component/Grid/Sort/Type/ResourceType.php
+++ b/src/Component/Grid/Sort/Type/ResourceType.php
@@ -11,7 +11,7 @@
 
 namespace Lug\Component\Grid\Sort\Type;
 
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,22 +22,22 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ResourceType extends AbstractType
 {
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @var ServiceRegistryInterface
+     * @var RegistryInterface
      */
     private $repositoryRegistry;
 
     /**
-     * @param ServiceRegistryInterface $resourceRegistry
-     * @param ServiceRegistryInterface $repositoryRegistry
+     * @param RegistryInterface $resourceRegistry
+     * @param RegistryInterface $repositoryRegistry
      */
     public function __construct(
-        ServiceRegistryInterface $resourceRegistry,
-        ServiceRegistryInterface $repositoryRegistry
+        RegistryInterface $resourceRegistry,
+        RegistryInterface $repositoryRegistry
     ) {
         $this->resourceRegistry = $resourceRegistry;
         $this->repositoryRegistry = $repositoryRegistry;

--- a/src/Component/Grid/Tests/Action/ActionRendererTest.php
+++ b/src/Component/Grid/Tests/Action/ActionRendererTest.php
@@ -16,7 +16,7 @@ use Lug\Component\Grid\Action\ActionRendererInterface;
 use Lug\Component\Grid\Action\Type\TypeInterface;
 use Lug\Component\Grid\Model\ActionInterface;
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -30,7 +30,7 @@ class ActionRendererTest extends \PHPUnit_Framework_TestCase
     private $renderer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $actionRegistry;
 
@@ -109,11 +109,11 @@ class ActionRendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Batch/BatcherTest.php
+++ b/src/Component/Grid/Tests/Batch/BatcherTest.php
@@ -16,7 +16,7 @@ use Lug\Component\Grid\Batch\BatcherInterface;
 use Lug\Component\Grid\Batch\Type\TypeInterface;
 use Lug\Component\Grid\Model\BatchInterface;
 use Lug\Component\Grid\Model\GridInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -30,7 +30,7 @@ class BatcherTest extends \PHPUnit_Framework_TestCase
     private $batcher;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $batchRegistry;
 
@@ -114,11 +114,11 @@ class BatcherTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Column/ColumnRendererTest.php
+++ b/src/Component/Grid/Tests/Column/ColumnRendererTest.php
@@ -16,7 +16,7 @@ use Lug\Component\Grid\Column\ColumnRendererInterface;
 use Lug\Component\Grid\Column\Type\TypeInterface;
 use Lug\Component\Grid\Model\ColumnInterface;
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -30,7 +30,7 @@ class ColumnRendererTest extends \PHPUnit_Framework_TestCase
     private $renderer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $columnRegistry;
 
@@ -109,11 +109,11 @@ class ColumnRendererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Column/Type/ResourceTypeTest.php
+++ b/src/Component/Grid/Tests/Column/Type/ResourceTypeTest.php
@@ -16,7 +16,7 @@ use Lug\Component\Grid\Column\Type\ResourceType;
 use Lug\Component\Grid\Column\Type\TypeInterface;
 use Lug\Component\Grid\Model\ColumnInterface;
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -37,7 +37,7 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     private $propertyAccessor;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -317,11 +317,11 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Filter/FiltererTest.php
+++ b/src/Component/Grid/Tests/Filter/FiltererTest.php
@@ -17,7 +17,7 @@ use Lug\Component\Grid\Filter\FiltererInterface;
 use Lug\Component\Grid\Filter\Type\TypeInterface;
 use Lug\Component\Grid\Model\FilterInterface;
 use Lug\Component\Grid\Model\GridInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,7 +31,7 @@ class FiltererTest extends \PHPUnit_Framework_TestCase
     private $filterer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $filterRegistry;
 
@@ -127,11 +127,11 @@ class FiltererTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Filter/Type/ResourceTypeTest.php
+++ b/src/Component/Grid/Tests/Filter/Type/ResourceTypeTest.php
@@ -16,7 +16,7 @@ use Lug\Component\Grid\DataSource\ExpressionBuilderInterface;
 use Lug\Component\Grid\Filter\Type\AbstractType;
 use Lug\Component\Grid\Filter\Type\ResourceType;
 use Lug\Component\Grid\Model\FilterInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -31,7 +31,7 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     private $type;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
@@ -300,11 +300,11 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Handler/GridHandlerTest.php
+++ b/src/Component/Grid/Tests/Handler/GridHandlerTest.php
@@ -20,7 +20,7 @@ use Lug\Component\Grid\Slicer\SlicerInterface;
 use Lug\Component\Grid\Sort\SorterInterface;
 use Lug\Component\Grid\View\GridViewFactoryInterface;
 use Lug\Component\Grid\View\GridViewInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Resource\Repository\RepositoryInterface;
 
@@ -35,7 +35,7 @@ class GridHandlerTest extends \PHPUnit_Framework_TestCase
     private $handler;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $repositoryRegistry;
 
@@ -154,11 +154,11 @@ class GridHandlerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Registry/ActionRegistryTest.php
+++ b/src/Component/Grid/Tests/Registry/ActionRegistryTest.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Tests\Registry;
 
 use Lug\Component\Grid\Action\Type\TypeInterface;
 use Lug\Component\Grid\Registry\ActionRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,7 +35,7 @@ class ActionRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->actionRegistry);
+        $this->assertInstanceOf(Registry::class, $this->actionRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Grid/Tests/Registry/BatchRegistryTest.php
+++ b/src/Component/Grid/Tests/Registry/BatchRegistryTest.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Tests\Registry;
 
 use Lug\Component\Grid\Batch\Type\TypeInterface;
 use Lug\Component\Grid\Registry\BatchRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,7 +35,7 @@ class BatchRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->batchRegistry);
+        $this->assertInstanceOf(Registry::class, $this->batchRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Grid/Tests/Registry/ColumnRegistryTest.php
+++ b/src/Component/Grid/Tests/Registry/ColumnRegistryTest.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Tests\Registry;
 
 use Lug\Component\Grid\Column\Type\TypeInterface;
 use Lug\Component\Grid\Registry\ColumnRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,7 +35,7 @@ class ColumnRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->columnRegistry);
+        $this->assertInstanceOf(Registry::class, $this->columnRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Grid/Tests/Registry/FilterRegistryTest.php
+++ b/src/Component/Grid/Tests/Registry/FilterRegistryTest.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Tests\Registry;
 
 use Lug\Component\Grid\Filter\Type\TypeInterface;
 use Lug\Component\Grid\Registry\FilterRegistry;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,7 +35,7 @@ class FilterRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->filterRegistry);
+        $this->assertInstanceOf(Registry::class, $this->filterRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Grid/Tests/Registry/SortRegistryTest.php
+++ b/src/Component/Grid/Tests/Registry/SortRegistryTest.php
@@ -13,7 +13,7 @@ namespace Lug\Component\Grid\Tests\Registry;
 
 use Lug\Component\Grid\Registry\SortRegistry;
 use Lug\Component\Grid\Sort\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,7 +35,7 @@ class SortRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistry::class, $this->sortRegistry);
+        $this->assertInstanceOf(Registry::class, $this->sortRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Grid/Tests/Sort/SorterTest.php
+++ b/src/Component/Grid/Tests/Sort/SorterTest.php
@@ -17,7 +17,7 @@ use Lug\Component\Grid\Model\SortInterface;
 use Lug\Component\Grid\Sort\Sorter;
 use Lug\Component\Grid\Sort\SorterInterface;
 use Lug\Component\Grid\Sort\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,7 +31,7 @@ class SorterTest extends \PHPUnit_Framework_TestCase
     private $sorter;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $sortRegistry;
 
@@ -127,11 +127,11 @@ class SorterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Grid/Tests/Sort/Type/ResourceTypeTest.php
+++ b/src/Component/Grid/Tests/Sort/Type/ResourceTypeTest.php
@@ -14,7 +14,7 @@ namespace Lug\Component\Grid\Tests\Sort\Type;
 use Lug\Component\Grid\DataSource\DataSourceBuilderInterface;
 use Lug\Component\Grid\Sort\Type\ResourceType;
 use Lug\Component\Grid\Sort\Type\TypeInterface;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,12 +30,12 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     private $type;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $resourceRegistry;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @var \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private $repositoryRegistry;
 
@@ -212,11 +212,11 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ServiceRegistryInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|RegistryInterface
      */
     private function createServiceRegistryMock()
     {
-        return $this->getMock(ServiceRegistryInterface::class);
+        return $this->getMock(RegistryInterface::class);
     }
 
     /**

--- a/src/Component/Registry/Model/Registry.php
+++ b/src/Component/Registry/Model/Registry.php
@@ -18,7 +18,7 @@ use Lug\Component\Registry\Exception\ServiceNotFoundException;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ServiceRegistry implements ServiceRegistryInterface
+class Registry implements RegistryInterface
 {
     /**
      * @var string

--- a/src/Component/Registry/Model/RegistryInterface.php
+++ b/src/Component/Registry/Model/RegistryInterface.php
@@ -14,7 +14,7 @@ namespace Lug\Component\Registry\Model;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-interface ServiceRegistryInterface extends
+interface RegistryInterface extends
     \ArrayAccess,
     \Countable,
     \IteratorAggregate

--- a/src/Component/Registry/Tests/Model/RegistryTest.php
+++ b/src/Component/Registry/Tests/Model/RegistryTest.php
@@ -11,18 +11,18 @@
 
 namespace Lug\Component\Registry\Tests\Model;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ServiceRegistryTest extends \PHPUnit_Framework_TestCase
+class RegistryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ServiceRegistry
+     * @var Registry
      */
-    private $serviceRegistry;
+    private $registry;
 
     /**
      * @var ServiceInterface[]
@@ -35,44 +35,44 @@ class ServiceRegistryTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->services = ['foo' => $this->createServiceMock(), 'bar' => $this->createServiceMock()];
-        $this->serviceRegistry = new ServiceRegistry(ServiceInterface::class, $this->services);
+        $this->registry = new Registry(ServiceInterface::class, $this->services);
     }
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->serviceRegistry);
-        $this->assertInstanceOf(\ArrayAccess::class, $this->serviceRegistry);
-        $this->assertInstanceOf(\Countable::class, $this->serviceRegistry);
-        $this->assertInstanceOf(\IteratorAggregate::class, $this->serviceRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->registry);
+        $this->assertInstanceOf(\ArrayAccess::class, $this->registry);
+        $this->assertInstanceOf(\Countable::class, $this->registry);
+        $this->assertInstanceOf(\IteratorAggregate::class, $this->registry);
     }
 
     public function testDefaultState()
     {
-        $this->serviceRegistry = new ServiceRegistry(ServiceInterface::class);
+        $this->registry = new Registry(ServiceInterface::class);
 
-        $this->assertEmpty(iterator_to_array($this->serviceRegistry));
-        $this->assertCount(0, $this->serviceRegistry);
+        $this->assertEmpty(iterator_to_array($this->registry));
+        $this->assertCount(0, $this->registry);
     }
 
     public function testInitialState()
     {
-        $this->assertSame($this->services, iterator_to_array($this->serviceRegistry));
-        $this->assertCount(count($this->services), $this->serviceRegistry);
+        $this->assertSame($this->services, iterator_to_array($this->registry));
+        $this->assertCount(count($this->services), $this->registry);
     }
 
     public function testOffsetExists()
     {
         foreach (array_keys($this->services) as $type) {
-            $this->assertTrue(isset($this->serviceRegistry[$type]));
+            $this->assertTrue(isset($this->registry[$type]));
         }
 
-        $this->assertFalse(isset($this->serviceRegistry['baz']));
+        $this->assertFalse(isset($this->registry['baz']));
     }
 
     public function testOffsetGet()
     {
         foreach ($this->services as $type => $service) {
-            $this->assertSame($service, $this->serviceRegistry[$type]);
+            $this->assertSame($service, $this->registry[$type]);
         }
     }
 
@@ -82,16 +82,16 @@ class ServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testOffsetGetWithNonExistingService()
     {
-        $this->serviceRegistry['baz'];
+        $this->registry['baz'];
     }
 
     public function testOffsetSet()
     {
-        $this->serviceRegistry[$type = 'baz'] = $service = $this->createServiceMock();
+        $this->registry[$type = 'baz'] = $service = $this->createServiceMock();
 
-        $this->assertSame($service, $this->serviceRegistry[$type]);
-        $this->assertSame(array_merge($this->services, [$type => $service]), iterator_to_array($this->serviceRegistry));
-        $this->assertCount(count($this->services) + 1, $this->serviceRegistry);
+        $this->assertSame($service, $this->registry[$type]);
+        $this->assertSame(array_merge($this->services, [$type => $service]), iterator_to_array($this->registry));
+        $this->assertCount(count($this->services) + 1, $this->registry);
     }
 
     /**
@@ -100,37 +100,37 @@ class ServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testOffsetSetWithExistingService()
     {
-        $this->serviceRegistry['foo'] = $this->createServiceMock();
+        $this->registry['foo'] = $this->createServiceMock();
     }
 
     /**
      * @expectedException \Lug\Component\Registry\Exception\InvalidServiceException
-     * @expectedExceptionMessage The service for the registry "Lug\Component\Registry\Model\ServiceRegistry" must be an instance of "Lug\Component\Registry\Tests\Model\ServiceInterface", got "string".
+     * @expectedExceptionMessage The service for the registry "Lug\Component\Registry\Model\Registry" must be an instance of "Lug\Component\Registry\Tests\Model\ServiceInterface", got "string".
      */
     public function testOffsetSetWithScalarService()
     {
-        $this->serviceRegistry['baz'] = 'baz';
+        $this->registry['baz'] = 'baz';
     }
 
     /**
      * @expectedException \Lug\Component\Registry\Exception\InvalidServiceException
-     * @expectedExceptionMessage The service for the registry "Lug\Component\Registry\Model\ServiceRegistry" must be an instance of "Lug\Component\Registry\Tests\Model\ServiceInterface", got "stdClass".
+     * @expectedExceptionMessage The service for the registry "Lug\Component\Registry\Model\Registry" must be an instance of "Lug\Component\Registry\Tests\Model\ServiceInterface", got "stdClass".
      */
     public function testOffsetSetWithInvalidService()
     {
-        $this->serviceRegistry['baz'] = new \stdClass();
+        $this->registry['baz'] = new \stdClass();
     }
 
     public function testOffsetUnset()
     {
         foreach (array_keys($this->services) as $type) {
-            unset($this->serviceRegistry[$type]);
+            unset($this->registry[$type]);
 
-            $this->assertFalse(isset($this->serviceRegistry[$type]));
+            $this->assertFalse(isset($this->registry[$type]));
         }
 
-        $this->assertEmpty(iterator_to_array($this->serviceRegistry));
-        $this->assertCount(0, $this->serviceRegistry);
+        $this->assertEmpty(iterator_to_array($this->registry));
+        $this->assertCount(0, $this->registry);
     }
 
     /**
@@ -139,7 +139,7 @@ class ServiceRegistryTest extends \PHPUnit_Framework_TestCase
      */
     public function testOffsetUnsetWithNonExistingService()
     {
-        unset($this->serviceRegistry['baz']);
+        unset($this->registry['baz']);
     }
 
     /**

--- a/src/Component/Resource/Registry/DomainManagerRegistry.php
+++ b/src/Component/Resource/Registry/DomainManagerRegistry.php
@@ -11,13 +11,13 @@
 
 namespace Lug\Component\Resource\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Lug\Component\Resource\Domain\DomainManagerInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class DomainManagerRegistry extends ServiceRegistry
+class DomainManagerRegistry extends Registry
 {
     /**
      * @param DomainManagerInterface[] $domainManagers

--- a/src/Component/Resource/Registry/FactoryRegistry.php
+++ b/src/Component/Resource/Registry/FactoryRegistry.php
@@ -11,13 +11,13 @@
 
 namespace Lug\Component\Resource\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Lug\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class FactoryRegistry extends ServiceRegistry
+class FactoryRegistry extends Registry
 {
     /**
      * @param FactoryInterface[] $factories

--- a/src/Component/Resource/Registry/ManagerRegistry.php
+++ b/src/Component/Resource/Registry/ManagerRegistry.php
@@ -12,12 +12,12 @@
 namespace Lug\Component\Resource\Registry;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ManagerRegistry extends ServiceRegistry
+class ManagerRegistry extends Registry
 {
     /**
      * @param ObjectManager[] $managers

--- a/src/Component/Resource/Registry/RepositoryRegistry.php
+++ b/src/Component/Resource/Registry/RepositoryRegistry.php
@@ -11,13 +11,13 @@
 
 namespace Lug\Component\Resource\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Lug\Component\Resource\Repository\RepositoryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RepositoryRegistry extends ServiceRegistry
+class RepositoryRegistry extends Registry
 {
     /**
      * @param RepositoryInterface[] $repositories

--- a/src/Component/Resource/Registry/ResourceRegistry.php
+++ b/src/Component/Resource/Registry/ResourceRegistry.php
@@ -11,13 +11,13 @@
 
 namespace Lug\Component\Resource\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
+use Lug\Component\Registry\Model\Registry;
 use Lug\Component\Resource\Model\ResourceInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class ResourceRegistry extends ServiceRegistry
+class ResourceRegistry extends Registry
 {
     /**
      * @param ResourceInterface[] $resources

--- a/src/Component/Resource/Tests/Registry/FactoryRegistryTest.php
+++ b/src/Component/Resource/Tests/Registry/FactoryRegistryTest.php
@@ -11,8 +11,8 @@
 
 namespace Lug\Component\Resource\Tests\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Factory\FactoryInterface;
 use Lug\Component\Resource\Registry\FactoryRegistry;
 
@@ -36,8 +36,8 @@ class FactoryRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->factoryRegistry);
-        $this->assertInstanceOf(ServiceRegistry::class, $this->factoryRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->factoryRegistry);
+        $this->assertInstanceOf(Registry::class, $this->factoryRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Resource/Tests/Registry/ManagerRegistryTest.php
+++ b/src/Component/Resource/Tests/Registry/ManagerRegistryTest.php
@@ -12,8 +12,8 @@
 namespace Lug\Component\Resource\Tests\Registry;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Registry\ManagerRegistry;
 
 /**
@@ -36,8 +36,8 @@ class ManagerRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->managerRegistry);
-        $this->assertInstanceOf(ServiceRegistry::class, $this->managerRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->managerRegistry);
+        $this->assertInstanceOf(Registry::class, $this->managerRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Resource/Tests/Registry/RepositoryRegistryTest.php
+++ b/src/Component/Resource/Tests/Registry/RepositoryRegistryTest.php
@@ -11,8 +11,8 @@
 
 namespace Lug\Component\Resource\Tests\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Registry\RepositoryRegistry;
 use Lug\Component\Resource\Repository\RepositoryInterface;
 
@@ -36,8 +36,8 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->repositoryRegistry);
-        $this->assertInstanceOf(ServiceRegistry::class, $this->repositoryRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->repositoryRegistry);
+        $this->assertInstanceOf(Registry::class, $this->repositoryRegistry);
     }
 
     public function testDefaultState()

--- a/src/Component/Resource/Tests/Registry/ResourceRegistryTest.php
+++ b/src/Component/Resource/Tests/Registry/ResourceRegistryTest.php
@@ -11,8 +11,8 @@
 
 namespace Lug\Component\Resource\Tests\Registry;
 
-use Lug\Component\Registry\Model\ServiceRegistry;
-use Lug\Component\Registry\Model\ServiceRegistryInterface;
+use Lug\Component\Registry\Model\Registry;
+use Lug\Component\Registry\Model\RegistryInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Lug\Component\Resource\Registry\ResourceRegistry;
 
@@ -36,8 +36,8 @@ class ResourceRegistryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritance()
     {
-        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->resourceRegistry);
-        $this->assertInstanceOf(ServiceRegistry::class, $this->resourceRegistry);
+        $this->assertInstanceOf(RegistryInterface::class, $this->resourceRegistry);
+        $this->assertInstanceOf(Registry::class, $this->resourceRegistry);
     }
 
     public function testDefaultState()


### PR DESCRIPTION
Using Service in the classname does not make real sense and can become confusing if you're in a Symfony context...

ping @tmartin 