### PR TITLE
[ResourceBundle] Move Serializer/Validation groups resolution

### DIFF
--- a/src/Bundle/ResourceBundle/Controller/Controller.php
+++ b/src/Bundle/ResourceBundle/Controller/Controller.php
@@ -225,7 +225,7 @@ class Controller extends FOSRestController implements ControllerInterface
      */
     private function buildForm($form = null, $object = null, array $options = [])
     {
-        return $this->getFormFactory()->create($this->resource, $form, $object, $options);
+        return $this->getFormFactory()->create($form ?: $this->resource, $object, $options);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Form/FormFactory.php
+++ b/src/Bundle/ResourceBundle/Form/FormFactory.php
@@ -14,6 +14,8 @@ namespace Lug\Bundle\ResourceBundle\Form;
 use Lug\Bundle\ResourceBundle\Routing\ParameterResolverInterface;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\Form\FormFactoryInterface as SymfonyFormFactoryInterface;
+use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\Form\Test\FormInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -41,15 +43,19 @@ class FormFactory implements FormFactoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string|FormTypeInterface|ResourceInterface $type
+     * @param mixed                                      $data
+     * @param mixed[]                                    $options
+     *
+     * @return FormInterface
      */
-    public function create(ResourceInterface $resource, $type = null, $data = null, array $options = [])
+    public function create($type = null, $data = null, array $options = [])
     {
-        if ($type === null) {
-            $type = $this->parameterResolver->resolveForm($resource);
+        if ($type instanceof ResourceInterface) {
+            $type = $this->parameterResolver->resolveForm($type);
         }
 
-        $validationGroups = $this->parameterResolver->resolveValidationGroups($resource);
+        $validationGroups = $this->parameterResolver->resolveValidationGroups();
         $translationDomain = $this->parameterResolver->resolveTranslationDomain();
 
         if (!empty($validationGroups)) {

--- a/src/Bundle/ResourceBundle/Form/FormFactoryInterface.php
+++ b/src/Bundle/ResourceBundle/Form/FormFactoryInterface.php
@@ -21,12 +21,11 @@ use Symfony\Component\Form\Test\FormInterface;
 interface FormFactoryInterface
 {
     /**
-     * @param ResourceInterface             $resource
-     * @param string|FormTypeInterface|null $type
-     * @param mixed                         $data
-     * @param mixed[]                       $options
+     * @param string|FormTypeInterface|ResourceInterface $type
+     * @param mixed                                      $data
+     * @param mixed[]                                    $options
      *
      * @return FormInterface
      */
-    public function create(ResourceInterface $resource, $type = null, $data = null, array $options = []);
+    public function create($type = null, $data = null, array $options = []);
 }

--- a/src/Bundle/ResourceBundle/Rest/View/EventSubscriber/GridViewSubscriber.php
+++ b/src/Bundle/ResourceBundle/Rest/View/EventSubscriber/GridViewSubscriber.php
@@ -95,7 +95,7 @@ class GridViewSubscriber extends AbstractSubscriber
 
         if ($grid->getBatchForm() === null) {
             $batchForm = !isset($data['batch_form']) || !$data['batch_form'] instanceof FormInterface
-                ? $this->formFactory->create($event->getResource(), GridBatchType::class, null, ['grid' => $grid])
+                ? $this->formFactory->create(GridBatchType::class, null, ['grid' => $grid])
                 : $data['batch_form'];
 
             $grid->setBatchForm($batchForm->createView());

--- a/src/Bundle/ResourceBundle/Rest/View/EventSubscriber/ResourceViewSubscriber.php
+++ b/src/Bundle/ResourceBundle/Rest/View/EventSubscriber/ResourceViewSubscriber.php
@@ -11,6 +11,7 @@
 
 namespace Lug\Bundle\ResourceBundle\Rest\View\EventSubscriber;
 
+use JMS\Serializer\Exclusion\GroupsExclusionStrategy;
 use Lug\Bundle\ResourceBundle\Rest\AbstractSubscriber;
 use Lug\Bundle\ResourceBundle\Rest\RestEvents;
 use Lug\Bundle\ResourceBundle\Rest\View\ViewEvent;
@@ -29,13 +30,15 @@ class ResourceViewSubscriber extends AbstractSubscriber
             return;
         }
 
-        $groups = $this->getParameterResolver()->resolveSerializerGroups($event->getResource());
-        $view = $event->getView();
+        $groups = $this->getParameterResolver()->resolveSerializerGroups();
 
-        if (!empty($groups)) {
-            $view->getContext()->addGroups($groups);
+        if (empty($groups)) {
+            $groups = [GroupsExclusionStrategy::DEFAULT_GROUP, 'lug.'.$event->getResource()->getName()];
         }
 
+        $view = $event->getView();
+
+        $view->getContext()->addGroups($groups);
         $view->getContext()->setSerializeNull($this->getParameterResolver()->resolveSerializerNull());
     }
 

--- a/src/Bundle/ResourceBundle/Routing/CachedParameterResolver.php
+++ b/src/Bundle/ResourceBundle/Routing/CachedParameterResolver.php
@@ -188,10 +188,10 @@ class CachedParameterResolver implements ParameterResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveSerializerGroups(ResourceInterface $resource)
+    public function resolveSerializerGroups()
     {
-        return !isset($this->cache[$key = 'serializer_groups_'.spl_object_hash($resource)])
-            ? $this->cache[$key] = $this->parameterResolver->resolveSerializerGroups($resource)
+        return !isset($this->cache[$key = 'serializer_groups'])
+            ? $this->cache[$key] = $this->parameterResolver->resolveSerializerGroups()
             : $this->cache[$key];
     }
 
@@ -248,10 +248,10 @@ class CachedParameterResolver implements ParameterResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveValidationGroups(ResourceInterface $resource)
+    public function resolveValidationGroups()
     {
-        return !isset($this->cache[$key = 'validation_groups_'.spl_object_hash($resource)])
-            ? $this->cache[$key] = $this->parameterResolver->resolveValidationGroups($resource)
+        return !isset($this->cache[$key = 'validation_groups'])
+            ? $this->cache[$key] = $this->parameterResolver->resolveValidationGroups()
             : $this->cache[$key];
     }
 

--- a/src/Bundle/ResourceBundle/Routing/ParameterResolver.php
+++ b/src/Bundle/ResourceBundle/Routing/ParameterResolver.php
@@ -11,14 +11,12 @@
 
 namespace Lug\Bundle\ResourceBundle\Routing;
 
-use JMS\Serializer\Exclusion\GroupsExclusionStrategy;
 use Lug\Bundle\ResourceBundle\Exception\RequestNotFoundException;
 use Lug\Bundle\ResourceBundle\Exception\RuntimeException;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\Validator\Constraint;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -233,12 +231,9 @@ class ParameterResolver implements ParameterResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveSerializerGroups(ResourceInterface $resource)
+    public function resolveSerializerGroups()
     {
-        return $this->resolveParameter(
-            'serializer_groups',
-            [GroupsExclusionStrategy::DEFAULT_GROUP, 'lug.'.$resource->getName()]
-        );
+        return $this->resolveParameter('serializer_groups', []);
     }
 
     /**
@@ -300,9 +295,9 @@ class ParameterResolver implements ParameterResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveValidationGroups(ResourceInterface $resource)
+    public function resolveValidationGroups()
     {
-        return $this->resolveParameter('validation_groups', [Constraint::DEFAULT_GROUP, 'lug.'.$resource->getName()]);
+        return $this->resolveParameter('validation_groups', []);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Routing/ParameterResolverInterface.php
+++ b/src/Bundle/ResourceBundle/Routing/ParameterResolverInterface.php
@@ -97,11 +97,9 @@ interface ParameterResolverInterface
     public function resolveRepositoryMethod($action);
 
     /**
-     * @param ResourceInterface $resource
-     *
      * @return string[]
      */
-    public function resolveSerializerGroups(ResourceInterface $resource);
+    public function resolveSerializerGroups();
 
     /**
      * @return bool
@@ -129,11 +127,9 @@ interface ParameterResolverInterface
     public function resolveTranslationDomain();
 
     /**
-     * @param ResourceInterface $resource
-     *
-     * @return string|null
+     * @return string[]
      */
-    public function resolveValidationGroups(ResourceInterface $resource);
+    public function resolveValidationGroups();
 
     /**
      * @return bool

--- a/src/Bundle/ResourceBundle/Tests/Form/FormFactoryTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Form/FormFactoryTest.php
@@ -53,27 +53,6 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(BundleFormFactoryInterface::class, $this->formFactory);
     }
 
-    public function testCreateWithResourceType()
-    {
-        $this->parameterResolver
-            ->expects($this->once())
-            ->method('resolveForm')
-            ->with($this->identicalTo($resource = $this->createResourceMock()))
-            ->will($this->returnValue($resourceType = 'resource_type'));
-
-        $this->symfonyFormFactory
-            ->expects($this->once())
-            ->method('create')
-            ->with(
-                $this->identicalTo($resourceType),
-                $this->identicalTo($data = 'data'),
-                $this->identicalTo($options = ['option'])
-            )
-            ->will($this->returnValue($form = 'form'));
-
-        $this->assertSame($form, $this->formFactory->create($resource, null, $data, $options));
-    }
-
     public function testCreateWithStringType()
     {
         $this->symfonyFormFactory
@@ -86,7 +65,28 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($form = 'form'));
 
-        $this->assertSame($form, $this->formFactory->create($this->createResourceMock(), $type, $data, $options));
+        $this->assertSame($form, $this->formFactory->create($type, $data, $options));
+    }
+
+    public function testCreateWithResourceType()
+    {
+        $this->parameterResolver
+            ->expects($this->once())
+            ->method('resolveForm')
+            ->with($this->identicalTo($type = $this->createResourceMock()))
+            ->will($this->returnValue($resourceType = 'resource_type'));
+
+        $this->symfonyFormFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->identicalTo($resourceType),
+                $this->identicalTo($data = 'data'),
+                $this->identicalTo($options = ['option'])
+            )
+            ->will($this->returnValue($form = 'form'));
+
+        $this->assertSame($form, $this->formFactory->create($type, $data, $options));
     }
 
     public function testCreateWithValidationGroups()
@@ -94,7 +94,6 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->parameterResolver
             ->expects($this->once())
             ->method('resolveValidationGroups')
-            ->with($this->identicalTo($resource = $this->createResourceMock()))
             ->will($this->returnValue($groups = ['group']));
 
         $this->symfonyFormFactory
@@ -107,7 +106,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($form = 'form'));
 
-        $this->assertSame($form, $this->formFactory->create($resource, $type, $data, $options));
+        $this->assertSame($form, $this->formFactory->create($type, $data, $options));
     }
 
     public function testCreateWithTranslationDomain()
@@ -127,7 +126,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($form = 'form'));
 
-        $this->assertSame($form, $this->formFactory->create($this->createResourceMock(), $type, $data, $options));
+        $this->assertSame($form, $this->formFactory->create($type, $data, $options));
     }
 
     public function testCreateWithApi()
@@ -147,7 +146,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($form = 'form'));
 
-        $this->assertSame($form, $this->formFactory->create($this->createResourceMock(), $type, $data, $options));
+        $this->assertSame($form, $this->formFactory->create($type, $data, $options));
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/Rest/View/EventSubscriber/GridViewSubscriberTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Rest/View/EventSubscriber/GridViewSubscriberTest.php
@@ -19,7 +19,6 @@ use Lug\Bundle\ResourceBundle\Rest\RestEvents;
 use Lug\Bundle\ResourceBundle\Rest\View\EventSubscriber\GridViewSubscriber;
 use Lug\Bundle\ResourceBundle\Rest\View\ViewEvent;
 use Lug\Bundle\ResourceBundle\Routing\ParameterResolverInterface;
-use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRendererInterface;
@@ -202,11 +201,6 @@ class GridViewSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('getView')
             ->will($this->returnValue($view = $this->createViewMock()));
 
-        $event
-            ->expects($this->once())
-            ->method('getResource')
-            ->will($this->returnValue($resource = $this->createResourceMock()));
-
         $view
             ->expects($this->once())
             ->method('getData')
@@ -216,7 +210,6 @@ class GridViewSubscriberTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('create')
             ->with(
-                $this->identicalTo($resource),
                 $this->identicalTo(GridBatchType::class),
                 $this->isNull(),
                 $this->identicalTo(['grid' => $gridView])
@@ -392,14 +385,6 @@ class GridViewSubscriberTest extends \PHPUnit_Framework_TestCase
         return $this->getMockBuilder(ViewEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ResourceInterface
-     */
-    private function createResourceMock()
-    {
-        return $this->getMock(ResourceInterface::class);
     }
 
     /**

--- a/src/Bundle/ResourceBundle/Tests/Routing/CachedParameterResolverTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Routing/CachedParameterResolverTest.php
@@ -238,11 +238,10 @@ class CachedParameterResolverTest extends \PHPUnit_Framework_TestCase
         $this->parameterResolver
             ->expects($this->once())
             ->method('resolveSerializerGroups')
-            ->with($resource = $this->createResourceMock())
             ->will($this->returnValue($groups = ['group']));
 
-        $this->assertSame($groups, $this->cachedParameterResolver->resolveSerializerGroups($resource));
-        $this->assertSame($groups, $this->cachedParameterResolver->resolveSerializerGroups($resource));
+        $this->assertSame($groups, $this->cachedParameterResolver->resolveSerializerGroups());
+        $this->assertSame($groups, $this->cachedParameterResolver->resolveSerializerGroups());
     }
 
     public function testResolveSerializerNull()
@@ -305,11 +304,10 @@ class CachedParameterResolverTest extends \PHPUnit_Framework_TestCase
         $this->parameterResolver
             ->expects($this->once())
             ->method('resolveValidationGroups')
-            ->with($this->identicalTo($resource = $this->createResourceMock()))
             ->will($this->returnValue($groups = ['group']));
 
-        $this->assertSame($groups, $this->cachedParameterResolver->resolveValidationGroups($resource));
-        $this->assertSame($groups, $this->cachedParameterResolver->resolveValidationGroups($resource));
+        $this->assertSame($groups, $this->cachedParameterResolver->resolveValidationGroups());
+        $this->assertSame($groups, $this->cachedParameterResolver->resolveValidationGroups());
     }
 
     public function testResolveVoter()

--- a/src/Bundle/ResourceBundle/Tests/Routing/ParameterResolverTest.php
+++ b/src/Bundle/ResourceBundle/Tests/Routing/ParameterResolverTest.php
@@ -11,14 +11,12 @@
 
 namespace Lug\Bundle\ResourceBundle\Tests\Routing;
 
-use JMS\Serializer\Exclusion\GroupsExclusionStrategy;
 use Lug\Bundle\ResourceBundle\Routing\ParameterResolver;
 use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\Validator\Constraint;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -786,16 +784,7 @@ class ParameterResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveSerializerGroupsWithoutRequest()
     {
-        $resource = $this->createResourceMock();
-        $resource
-            ->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue($name = 'name'));
-
-        $this->assertSame(
-            [GroupsExclusionStrategy::DEFAULT_GROUP, 'lug.'.$name],
-            $this->parameterResolver->resolveSerializerGroups($resource)
-        );
+        $this->assertEmpty($this->parameterResolver->resolveSerializerGroups());
     }
 
     public function testResolveSerializerGroupsDefault()
@@ -805,22 +794,16 @@ class ParameterResolverTest extends \PHPUnit_Framework_TestCase
             ->method('getMasterRequest')
             ->will($this->returnValue($request = $this->createRequestMock()));
 
-        $resource = $this->createResourceMock();
-        $resource
-            ->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue($name = 'name'));
-
         $request->attributes
             ->expects($this->once())
             ->method('get')
             ->with(
                 $this->identicalTo('_lug_serializer_groups'),
-                $this->identicalTo($groups = [GroupsExclusionStrategy::DEFAULT_GROUP, 'lug.'.$name])
+                $this->identicalTo($groups = [])
             )
             ->will($this->returnValue($groups));
 
-        $this->assertSame($groups, $this->parameterResolver->resolveSerializerGroups($resource));
+        $this->assertEmpty($this->parameterResolver->resolveSerializerGroups());
     }
 
     public function testResolveSerializerGroupsExplicit()
@@ -830,22 +813,16 @@ class ParameterResolverTest extends \PHPUnit_Framework_TestCase
             ->method('getMasterRequest')
             ->will($this->returnValue($request = $this->createRequestMock()));
 
-        $resource = $this->createResourceMock();
-        $resource
-            ->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue($name = 'name'));
-
         $request->attributes
             ->expects($this->once())
             ->method('get')
             ->with(
                 $this->identicalTo('_lug_serializer_groups'),
-                $this->identicalTo([GroupsExclusionStrategy::DEFAULT_GROUP, 'lug.'.$name])
+                $this->identicalTo([])
             )
             ->will($this->returnValue($groups = ['group']));
 
-        $this->assertSame($groups, $this->parameterResolver->resolveSerializerGroups($resource));
+        $this->assertSame($groups, $this->parameterResolver->resolveSerializerGroups());
     }
 
     public function testResolveSerializerNullWithoutRequest()
@@ -1105,16 +1082,7 @@ class ParameterResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveValidationGroupsWithoutRequest()
     {
-        $resource = $this->createResourceMock();
-        $resource
-            ->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue($name = 'name'));
-
-        $this->assertSame(
-            [Constraint::DEFAULT_GROUP, 'lug.'.$name],
-            $this->parameterResolver->resolveValidationGroups($resource)
-        );
+        $this->assertEmpty($this->parameterResolver->resolveValidationGroups());
     }
 
     public function testResolveValidationGroupsDefault()
@@ -1124,22 +1092,13 @@ class ParameterResolverTest extends \PHPUnit_Framework_TestCase
             ->method('getMasterRequest')
             ->will($this->returnValue($request = $this->createRequestMock()));
 
-        $resource = $this->createResourceMock();
-        $resource
-            ->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue($name = 'name'));
-
         $request->attributes
             ->expects($this->once())
             ->method('get')
-            ->with(
-                $this->identicalTo('_lug_validation_groups'),
-                $this->identicalTo($groups = [Constraint::DEFAULT_GROUP, 'lug.'.$name])
-            )
+            ->with($this->identicalTo('_lug_validation_groups'), $this->identicalTo($groups = []))
             ->will($this->returnValue($groups));
 
-        $this->assertSame($groups, $this->parameterResolver->resolveValidationGroups($resource));
+        $this->assertEmpty($this->parameterResolver->resolveValidationGroups());
     }
 
     public function testResolveValidationGroupsExplicit()
@@ -1149,22 +1108,13 @@ class ParameterResolverTest extends \PHPUnit_Framework_TestCase
             ->method('getMasterRequest')
             ->will($this->returnValue($request = $this->createRequestMock()));
 
-        $resource = $this->createResourceMock();
-        $resource
-            ->expects($this->once())
-            ->method('getName')
-            ->will($this->returnValue($name = 'name'));
-
         $request->attributes
             ->expects($this->once())
             ->method('get')
-            ->with(
-                $this->identicalTo('_lug_validation_groups'),
-                $this->identicalTo([Constraint::DEFAULT_GROUP, 'lug.'.$name])
-            )
+            ->with($this->identicalTo('_lug_validation_groups'), $this->identicalTo([]))
             ->will($this->returnValue($groups = ['group']));
 
-        $this->assertSame($groups, $this->parameterResolver->resolveValidationGroups($resource));
+        $this->assertSame($groups, $this->parameterResolver->resolveValidationGroups());
     }
 
     public function testResolveVoterWithoutRequest()

--- a/src/Component/Resource/Form/Type/ResourceType.php
+++ b/src/Component/Resource/Form/Type/ResourceType.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraint;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -38,6 +39,9 @@ class ResourceType extends AbstractType
                 },
                 'label_prefix' => function (Options $options) {
                     return 'lug.'.$options['resource']->getName();
+                },
+                'validation_groups' => function (Options $options) {
+                    return [Constraint::DEFAULT_GROUP, 'lug.'.$options['resource']->getName()];
                 },
                 'empty_data' => function (FormInterface $form) {
                     return $form->isRequired() || !$form->isEmpty()

--- a/src/Component/Resource/Tests/Form/Type/ResourceTypeTest.php
+++ b/src/Component/Resource/Tests/Form/Type/ResourceTypeTest.php
@@ -17,6 +17,7 @@ use Lug\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Forms;
+use Symfony\Component\Validator\Constraint;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -54,7 +55,7 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
     {
         $resource = $this->createResourceMock();
         $resource
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getName')
             ->will($this->returnValue($name = 'name'));
 
@@ -80,6 +81,12 @@ class ResourceTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($factory, $form->getConfig()->getOption('factory'));
         $this->assertSame($model, $form->getConfig()->getOption('data_class'));
         $this->assertSame('lug.'.$name, $form->getConfig()->getOption('label_prefix'));
+
+        $this->assertSame(
+            [Constraint::DEFAULT_GROUP, 'lug.'.$name],
+            $form->getConfig()->getOption('validation_groups')
+        );
+
         $this->assertSame($object, $form->getData());
 
         $form->createView();


### PR DESCRIPTION
This PR moves the serializer/validation groups outside the routing parameter resolver otherwise we can't customize validation groups according to the submitted data in the form...