### PR TITLE
Use stable version of the multipart stream builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/mink-selenium2-driver": "^1.3",
         "php-http/discovery": "^1.0",
         "php-http/message": "^1.3",
-        "php-http/multipart-stream-builder": "^0.1",
+        "php-http/multipart-stream-builder": "^1.0",
         "php-http/guzzle6-adapter": "^1.1",
         "coduo/php-matcher": "^2.0",
         "friendsofphp/php-cs-fixer": "^1.11"


### PR DESCRIPTION
There is one thing that might be considered as a BC break. If we, for whatever reason, added multiple streams/post data with the same name. Before they were overridden but since 0.2.0 we do allow duplicate values. 